### PR TITLE
Add mapping builder for a better interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,14 @@
       "Mw\\JsonMapping\\": "src"
     }
   },
+  "autoload-dev": {
+    "files": [
+      "vendor/phpunit/phpunit/src/Framework/Assert/Functions.php"
+    ],
+    "psr-4": {
+      "Mw\\JsonMapping\\Tests\\": "tests"
+    }
+  },
   "require-dev": {
     "phpunit/phpunit": "^5.2"
   }

--- a/src/MappingBuilder.php
+++ b/src/MappingBuilder.php
@@ -2,38 +2,71 @@
 namespace Mw\JsonMapping;
 
 
+/**
+ * Helper class for quickly building new mappings
+ *
+ * @package Mw\JsonMapping
+ */
 class MappingBuilder
 {
+    /**
+     * @return IntegerMapping
+     */
     public function toInteger()
     {
         return new IntegerMapping;
     }
 
+    /**
+     * @return FloatMapping
+     */
     public function toFloat()
     {
         return new FloatMapping;
     }
 
+    /**
+     * @param array $config
+     * @return ObjectMapping
+     */
     public function struct(array $config)
     {
         return new ObjectMapping($config);
     }
 
+    /**
+     * @param string $getter
+     * @return ObjectGetterMapping
+     */
     public function getter($getter)
     {
         return new ObjectGetterMapping($getter);
     }
 
+    /**
+     * @param MappingInterface $inner
+     * @return ListMapping
+     */
     public function listing(MappingInterface $inner)
     {
         return new ListMapping($inner);
     }
 
-    public function getterAndStruct($getter, $config)
+    /**
+     * @param string $getter
+     * @param array  $config
+     * @return MappingChain
+     */
+    public function getterAndStruct($getter, array $config)
     {
         return $this->getter($getter)->then($this->struct($config));
     }
 
+    /**
+     * @param string           $getter
+     * @param MappingInterface $inner
+     * @return MappingChain
+     */
     public function getterAndListing($getter, MappingInterface $inner)
     {
         return $this->getter($getter)->then($this->listing($inner));

--- a/src/MappingBuilder.php
+++ b/src/MappingBuilder.php
@@ -1,0 +1,41 @@
+<?php
+namespace Mw\JsonMapping;
+
+
+class MappingBuilder
+{
+    public function toInteger()
+    {
+        return new IntegerMapping;
+    }
+
+    public function toFloat()
+    {
+        return new FloatMapping;
+    }
+
+    public function struct(array $config)
+    {
+        return new ObjectMapping($config);
+    }
+
+    public function getter($getter)
+    {
+        return new ObjectGetterMapping($getter);
+    }
+
+    public function listing(MappingInterface $inner)
+    {
+        return new ListMapping($inner);
+    }
+
+    public function getterAndStruct($getter, $config)
+    {
+        return $this->getter($getter)->then($this->struct($config));
+    }
+
+    public function getterAndListing($getter, MappingInterface $inner)
+    {
+        return $this->getter($getter)->then($this->listing($inner));
+    }
+}

--- a/tests/Fixture/Customer.php
+++ b/tests/Fixture/Customer.php
@@ -1,0 +1,56 @@
+<?php
+namespace Mw\JsonMapping\Tests\Fixture;
+
+
+class Customer
+{
+    private $customerNumber;
+    private $firstName;
+    private $lastName;
+    /**
+     * @var array
+     */
+    private $invoices;
+
+    public function __construct($customerNumber, $firstName, $lastName, array $invoices)
+    {
+        $this->customerNumber = $customerNumber;
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+        $this->invoices = $invoices;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCustomerNumber()
+    {
+        return $this->customerNumber;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFirstName()
+    {
+        return $this->firstName;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLastName()
+    {
+        return $this->lastName;
+    }
+
+    /**
+     * @return array
+     */
+    public function getInvoices()
+    {
+        return $this->invoices;
+    }
+
+
+}

--- a/tests/Fixture/Invoice.php
+++ b/tests/Fixture/Invoice.php
@@ -1,0 +1,33 @@
+<?php
+namespace Mw\JsonMapping\Tests\Fixture;
+
+
+class Invoice
+{
+    private $invoiceNumber;
+    private $amount;
+
+    public function __construct($invoiceNumber, $amount)
+    {
+        $this->invoiceNumber = $invoiceNumber;
+        $this->amount = $amount;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getInvoiceNumber()
+    {
+        return $this->invoiceNumber;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+
+}

--- a/tests/MappingBuilderTest.php
+++ b/tests/MappingBuilderTest.php
@@ -1,0 +1,43 @@
+<?php
+namespace Mw\JsonMapping\Tests;
+
+use Mw\JsonMapping\MappingBuilder;
+use Mw\JsonMapping\Tests\Fixture\Customer;
+use Mw\JsonMapping\Tests\Fixture\Invoice;
+
+class MappingBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testMappingIsBuiltCorrectly()
+    {
+        $customer = new Customer(
+            '1234',
+            'John',
+            'Doe',
+            [
+                new Invoice(1000, "123.99"),
+                new Invoice(1001, "321.99"),
+            ]
+        );
+
+        $m = new MappingBuilder();
+        $mapping = $m->struct([
+            'uid'       => $m->getter('getCustomernumber')->then($m->toInteger()),
+            'firstName' => $m->getter('getFirstName'),
+            'lastName'  => $m->getter('getLastName'),
+            'invoices'  => $m->getterAndListing('getInvoices', $m->struct([
+                'uid'    => $m->getter('getInvoiceNumber')->then($m->toInteger()),
+                'amount' => $m->getter('getAmount')->then($m->toFloat())
+            ]))
+        ]);
+
+        assertThat($mapping->map($customer), identicalTo([
+            'uid' => 1234,
+            'firstName' => 'John',
+            'lastName' => 'Doe',
+            'invoices' => [
+                ['uid' => 1000, 'amount' => 123.99],
+                ['uid' => 1001, 'amount' => 321.99],
+            ]
+        ]));
+    }
+}

--- a/tests/SourceObject.php
+++ b/tests/SourceObject.php
@@ -3,6 +3,7 @@ namespace Mw\JsonMapping\Tests;
 
 /**
  * Class TestObject
+ *
  * @package Mw\JsonMapping\Tests
  */
 class SourceObject
@@ -21,7 +22,6 @@ class SourceObject
     protected $title = "Example Object";
 
 
-
     /**
      * @return int
      */
@@ -29,4 +29,5 @@ class SourceObject
     {
         return $this->uid;
     }
+
 }


### PR DESCRIPTION
This PR adds a new class `Mw\JsonMapping\MappingBuilder` that offers a more concise interface for building complex mappings (see modified README or test cases for examples).
