### PR TITLE
Do not use "static" to instantiate nested ObjectMappings

### DIFF
--- a/src/ObjectMapping.php
+++ b/src/ObjectMapping.php
@@ -41,7 +41,7 @@ class ObjectMapping extends AbstractMapping
             } else if (is_callable($subMapping)) {
                 $mapped = $subMapping($value);
             } else if (is_array($subMapping)) {
-                $subMapping = new static($subMapping);
+                $subMapping = new ObjectMapping($subMapping);
                 $mapped = $subMapping->map($value);
             }
             $result[$key] = $mapped;


### PR DESCRIPTION
This will break use cases in which custom mappings are used that
overwrite the base `ObjectMappings` class with a custom constructor.